### PR TITLE
feat: added config option prefixEntityNamesWithCarName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 build_*
 .idea
 Folder.DotSettings.user
+**/.vs/

--- a/FiatChampAddon/CHANGELOG.md
+++ b/FiatChampAddon/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.x.x - yyyy-mm-dd
+- added option to prefix entity names with the name of the car
+
 ## 3.0.7 - 2022-12-03
 - fixed commands for jeep america #27
 

--- a/FiatChampAddon/FiatClient/AppConfig.cs
+++ b/FiatChampAddon/FiatClient/AppConfig.cs
@@ -20,11 +20,12 @@ public record AppConfig
   public FcaBrand Brand { get; set; }
   public FcaRegion Region { get; set; } = FcaRegion.Europe;
   public string HomeAssistantUrl { get; set; } = "http://supervisor/core";
-  public int StartDelaySeconds { get; set; } = 1; 
+  public int StartDelaySeconds { get; set; } = 1;
   public bool AutoRefreshLocation { get; set; } = false;
   public bool AutoRefreshBattery { get; set; } = false;
   public bool EnableDangerousCommands { get; set; } = false;
   public bool ConvertKmToMiles { get; set; } = false;
+  public bool PrefixEntityNamesWithCarName { get; set; } = false;
   public bool DevMode { get; set; } = false;
   public bool UseFakeApi { get; set; } = false;
   public bool Debug { get; set; } = false;
@@ -44,7 +45,7 @@ public record AppConfig
 
     return JsonConvert.SerializeObject(tmp, Formatting.Indented, new StringEnumConverter());
   }
-  
+
   public bool IsPinSet()
   {
     return !string.IsNullOrWhiteSpace(this.FiatPin);

--- a/FiatChampAddon/FiatClient/HomeAssistant.cs
+++ b/FiatChampAddon/FiatClient/HomeAssistant.cs
@@ -121,10 +121,10 @@ public abstract class HaEntity
   
   public string Name => _name;
 
-  protected HaEntity(SimpleMqttClient mqttClient, string name, HaDevice haDevice)
+  protected HaEntity(SimpleMqttClient mqttClient, string name, bool prefixNameWithCar, HaDevice haDevice)
   {
     _mqttClient = mqttClient;
-    _name = name;
+    _name = prefixNameWithCar ? $"{haDevice.Name}_{name}" : name;
     _haDevice = haDevice;
     _id = $"{haDevice.Identifier}_{name}";
   }
@@ -143,8 +143,8 @@ public class HaDeviceTracker : HaEntity
   public double Lon { get; set; }
   public string StateValue { get; set; }
 
-  public HaDeviceTracker(SimpleMqttClient mqttClient, string name, HaDevice haDevice) 
-    : base(mqttClient, name, haDevice)
+  public HaDeviceTracker(SimpleMqttClient mqttClient, string name, bool prefixNameWithCar, HaDevice haDevice) 
+    : base(mqttClient, name, prefixNameWithCar, haDevice)
   {
     _stateTopic = $"homeassistant/sensor/{_id}/state";
     _configTopic = $"homeassistant/sensor/{_id}/config";
@@ -199,7 +199,8 @@ public class HaSensor : HaEntity
   private readonly string _stateTopic;
   private readonly string _configTopic;
 
-  public HaSensor(SimpleMqttClient mqttClient, string name, HaDevice haDevice) : base(mqttClient, name, haDevice)
+  public HaSensor(SimpleMqttClient mqttClient, string name, bool prefixNameWithCar, HaDevice haDevice) 
+        : base(mqttClient, name, prefixNameWithCar, haDevice)
   {
     _stateTopic = $"homeassistant/sensor/{_id}/state";
     _configTopic = $"homeassistant/sensor/{_id}/config";
@@ -248,8 +249,8 @@ public class HaButton : HaEntity
   private readonly string _commandTopic;
   private readonly string _configTopic;
 
-  public HaButton(SimpleMqttClient mqttClient, string name, HaDevice haDevice, Func<HaButton, Task> onPressedCommand)
-    : base(mqttClient, name, haDevice)
+  public HaButton(SimpleMqttClient mqttClient, string name, bool prefixNameWithCar, HaDevice haDevice, Func<HaButton, Task> onPressedCommand)
+    : base(mqttClient, name, prefixNameWithCar, haDevice)
   {
     _commandTopic = $"homeassistant/button/{_id}/set";
     _configTopic = $"homeassistant/button/{_id}/config";
@@ -299,8 +300,8 @@ public class HaSwitch : HaEntity
     _ = this.PublishState();
   }
 
-  public HaSwitch(SimpleMqttClient mqttClient, string name, HaDevice haDevice, Func<HaSwitch, Task> onSwitchCommand) 
-    : base(mqttClient, name, haDevice)
+  public HaSwitch(SimpleMqttClient mqttClient, string name, bool prefixNameWithCar, HaDevice haDevice, Func<HaSwitch, Task> onSwitchCommand) 
+    : base(mqttClient, name, prefixNameWithCar, haDevice)
   {
     _commandTopic = $"homeassistant/switch/{_id}/set";
     _stateTopic = $"homeassistant/switch/{_id}/state";

--- a/FiatChampAddon/FiatClient/Program.cs
+++ b/FiatChampAddon/FiatClient/Program.cs
@@ -105,7 +105,7 @@ await app.RunAsync(async (CoconaAppContext ctx) =>
 
         Log.Debug("Zones: {0}", zones.Dump());
 
-        var tracker = new HaDeviceTracker(mqttClient, "CAR_LOCATION", haDevice)
+        var tracker = new HaDeviceTracker(mqttClient, "CAR_LOCATION", appConfig.PrefixEntityNamesWithCarName, haDevice)
         {
           Lat = currentCarLocation.Latitude.ToDouble(),
           Lon = currentCarLocation.Longitude.ToDouble(),
@@ -129,7 +129,7 @@ await app.RunAsync(async (CoconaAppContext ctx) =>
 
         var sensors = compactDetails.Select(detail =>
         {
-          var sensor = new HaSensor(mqttClient, detail.Key, haDevice)
+          var sensor = new HaSensor(mqttClient, detail.Key, appConfig.PrefixEntityNamesWithCarName, haDevice)
           {
             Value = detail.Value
           };
@@ -192,7 +192,7 @@ await app.RunAsync(async (CoconaAppContext ctx) =>
 
         await Parallel.ForEachAsync(sensors.Values, async (sensor, token) => { await sensor.PublishState(); });
 
-        var lastUpdate = new HaSensor(mqttClient, "LAST_UPDATE", haDevice)
+        var lastUpdate = new HaSensor(mqttClient, "LAST_UPDATE", appConfig.PrefixEntityNamesWithCarName, haDevice)
         {
           Value = DateTime.Now.ToString("O"),
           DeviceClass = "timestamp"
@@ -278,49 +278,49 @@ async Task<bool> TrySendCommand(IFiatClient fiatClient, FiatCommand command, str
 IEnumerable<HaEntity> CreateInteractiveEntities(IFiatClient fiatClient, SimpleMqttClient mqttClient, Vehicle vehicle,
   HaDevice haDevice)
 {
-  var updateLocationButton = new HaButton(mqttClient, "UpdateLocation", haDevice, async button =>
+  var updateLocationButton = new HaButton(mqttClient, "UpdateLocation", appConfig.PrefixEntityNamesWithCarName, haDevice, async button =>
   {
     if (await TrySendCommand(fiatClient, FiatCommand.VF, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var batteryRefreshButton = new HaButton(mqttClient, "RefreshBatteryStatus", haDevice, async button =>
+  var batteryRefreshButton = new HaButton(mqttClient, "RefreshBatteryStatus", appConfig.PrefixEntityNamesWithCarName, haDevice, async button =>
   {
     if (await TrySendCommand(fiatClient, FiatCommand.DEEPREFRESH, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var deepRefreshButton = new HaButton(mqttClient, "DeepRefresh", haDevice, async button =>
+  var deepRefreshButton = new HaButton(mqttClient, "DeepRefresh", appConfig.PrefixEntityNamesWithCarName, haDevice, async button =>
   {
     if (await TrySendCommand(fiatClient, FiatCommand.DEEPREFRESH, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var locateLightsButton = new HaButton(mqttClient, "Blink", haDevice, async button =>
+  var locateLightsButton = new HaButton(mqttClient, "Blink", appConfig.PrefixEntityNamesWithCarName, haDevice, async button =>
   {
     if (await TrySendCommand(fiatClient, FiatCommand.HBLF, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var chargeNowButton = new HaButton(mqttClient, "ChargeNOW", haDevice, async button =>
+  var chargeNowButton = new HaButton(mqttClient, "ChargeNOW", appConfig.PrefixEntityNamesWithCarName, haDevice, async button =>
   {
     if (await TrySendCommand(fiatClient, FiatCommand.CNOW, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var trunkSwitch = new HaSwitch(mqttClient, "Trunk", haDevice, async sw =>
+  var trunkSwitch = new HaSwitch(mqttClient, "Trunk", appConfig.PrefixEntityNamesWithCarName, haDevice, async sw =>
   {
     if (await TrySendCommand(fiatClient, sw.IsOn ? FiatCommand.ROTRUNKUNLOCK : FiatCommand.ROTRUNKLOCK, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var hvacSwitch = new HaSwitch(mqttClient, "HVAC", haDevice, async sw =>
+  var hvacSwitch = new HaSwitch(mqttClient, "HVAC", appConfig.PrefixEntityNamesWithCarName, haDevice, async sw =>
   {
     if (await TrySendCommand(fiatClient, sw.IsOn ? FiatCommand.ROPRECOND : FiatCommand.ROPRECOND_OFF, vehicle.Vin))
       forceLoopResetEvent.Set();
   });
 
-  var lockSwitch = new HaSwitch(mqttClient, "DoorLock", haDevice, async sw =>
+  var lockSwitch = new HaSwitch(mqttClient, "DoorLock", appConfig.PrefixEntityNamesWithCarName, haDevice, async sw =>
   {
     if (await TrySendCommand(fiatClient, sw.IsOn ? FiatCommand.RDL : FiatCommand.RDU, vehicle.Vin))
       forceLoopResetEvent.Set();

--- a/FiatChampAddon/config.yaml
+++ b/FiatChampAddon/config.yaml
@@ -20,6 +20,7 @@ options:
   Debug: false
   AutoRefreshBattery: false
   AutoRefreshLocation: false
+  PrefixEntityNamesWithCarName: false
   EnableDangerousCommands: false
   CarUnknownLocation: "away"
   StartDelaySeconds: 1
@@ -34,6 +35,7 @@ schema:
   Debug: bool
   AutoRefreshBattery: bool
   AutoRefreshLocation: bool
+  PrefixEntityNamesWithCarName: bool
   EnableDangerousCommands: bool
   OverrideMqttUser: str?
   OverrideMqttPw: password?

--- a/FiatChampAddon/run.sh
+++ b/FiatChampAddon/run.sh
@@ -26,6 +26,7 @@ if [ -z ${STANDALONE+x} ]; then
   
   export FiatChamp_AutoRefreshLocation=$(bashio::config 'AutoRefreshLocation')
   export FiatChamp_AutoRefreshBattery=$(bashio::config 'AutoRefreshBattery')
+  export FiatChamp_PrefixEntityNamesWithCarName=$(bashio::config 'PrefixEntityNamesWithCarName')
   export FiatChamp_EnableDangerousCommands=$(bashio::config 'EnableDangerousCommands')
   
   export FiatChamp_Debug=$(bashio::config 'Debug')


### PR DESCRIPTION
Hi @wubbl0rz,

Here is a suggestion how the functionality in #31 could be implemented.
Unfortunately the formatting of my Visual Studio changed the whole indentation, can you provide me the used settings so that I can correct the issue.

Mainly I added a new configuration option (bool) to AppConfig and config.yml, then pushed the value down to the HaEntity class constructor to prefix the name of the entity with the device/car name.

Implements #31.

Best regards,
@CyberDNS

